### PR TITLE
Reduce boost download cost by migrating to a tarball of boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ FetchContent_MakeAvailable(cxxopts)
 set(BOOST_INCLUDE_LIBRARIES system filesystem process regex lexical_cast process scope_exit asio uuid serialization interprocess)
 FetchContent_Declare(
   boost
-  GIT_REPOSITORY https://github.com/boostorg/boost.git
-  GIT_TAG        ab7968a0bbcf574a7859240d1d8443f58ed6f6cf # tag boost-1.85.0
+  URL      https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-cmake.tar.gz
+  URL_HASH MD5=b21c059b592a041e90ae328fc5a8861b # tag boost-1.85.0
 )
 
 FetchContent_MakeAvailable(boost)


### PR DESCRIPTION
the aim of this pr is to be able to use the correct version of boost from the boost release. This avoids the cost of cloning each boost submodule. 