### PR TITLE
BUILD_TESTING conditionally compiles goldilock test suite + fix test_helpers missing header

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - develop
   pull_request:
 env:
-  version_in_development: v1.2.0
+  version_in_development: v1.2.1
 
 jobs:
   draft-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install and build 
         run: |
-          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
           cd build/macos/ && cpack -G ZIP
       - name: Upload goldilock package
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install and build 
         run: |
-          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
           cd build/macos/ 
           cpack -G ZIP
@@ -123,7 +123,7 @@ jobs:
           
       - name: install and build 
         run: |
-          tipi run cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17-static.cmake -DCMAKE_BUILD_TYPE=Release
+          tipi run cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17-static.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           tipi run cmake --build build/linux
           cd build/linux/
           tipi run cpack -G ZIP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ project(goldilock
   LANGUAGES CXX
 )
 
-enable_testing()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -47,4 +45,10 @@ target_include_directories(libgoldilock-utils INTERFACE
 )
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+# BUILD_TESTING is CTest module's default, but we prefer it OFF by default
+# Instead of include(CTest) we check on the option ourselves.
+if (BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -58,22 +58,23 @@ Usage:
 Building
 --------
 
-Build using `tipi` (substitute the toolchain your platform of choice e.g. `windows-cxx17` or `vs-16-2019-win64-cxx17` etc...)
+By using the provided `cmake` build system:
 
 ```shell
-tipi . -t linux-cxx17
-```
-
-... or by using the provided `cmake` build system:
-
-```shell
-mkdir -p build/linux
-cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17.cmake
+cmake -S . -B build/linux -GNinja -DBUILD_TESTING=ON
 cmake --build build/linux
 ```
 
+Developing the project
+--------
+If you plan to develop the project and contribute to it, you will need to enable `-DBUILD_TESTING=ON`.
+
+```shell
+cmake -S . -B build/linux -GNinja -DBUILD_TESTING=ON
+cmake --build build/linux
+```
 
 License
 -------
 
-`goldilock` is available under a proprietary license or subject to GPLv2 licence as per your choice. Please contact [tipi technologies Ltd.](https://tipi.build/) for commercial options.
+`goldilock` is available under a proprietary license or subject to GPLv2 licence as per your choice. Please contact [tipi technologies Ltd.](https://tipi.build/) for more details.

--- a/include/goldilock/version.hpp.in
+++ b/include/goldilock/version.hpp.in
@@ -2,6 +2,6 @@
 #include <string>
 
 namespace tipi::goldilock {
-    const std::string GOLDILOCK_VERSION = "v1.2.0";
+    const std::string GOLDILOCK_VERSION = "v1.2.1";
     const std::string GOLDILOCK_GIT_REVISION = "@GOLDILOCK_GIT_REVISION@";
 }

--- a/test/test_helpers.hpp
+++ b/test/test_helpers.hpp
@@ -12,6 +12,8 @@
 #include <iostream>
 #include <string>
 #include <optional>
+#include <thread>
+
 
 
 namespace goldilock::test { 


### PR DESCRIPTION
When HFC provisions goldilock on a platform where pre-released binaries are incompatible, it builds with default CMake flags, which did build all test with it which is wasteful in such scenario.

CMake common practice is to rely on BUILD_TESTING, which would be automatically defined  when doing `include(CTest)`, this would however set a BUILD_TESTING option with the default to ON  ( c.f. https://cmake.org/cmake/help/latest/module/CTest.html ). We think that especially for goldilock which is more like a dependency than a main project being worked on for it's target audience we prefer this being OFF by default.

Thanks to @enolan-maystreet for reporting this issue.

- Fix tipi-build/specs-cmake-re#57