### PR TITLE
[RELEASE] v1.2.1 

### DIFF
--- a/.github/ISSUE_TEMPLATE/RELEASING.md
+++ b/.github/ISSUE_TEMPLATE/RELEASING.md
@@ -1,0 +1,24 @@
+---
+name: Release 
+about: Checklist to make a release
+title: "[RELEASE] v1.0."
+labels: ''
+assignees: ''
+
+---
+
+# Release Process
+The goldilock development and release process follow the typical [git-flow](https://nvie.com/posts/a-successful-git-branching-model/) model.
+
+To perform a new release, the following is required :
+
+- [ ] Merge fixes and features for the release in `develop`
+- [ ] Create a pull-request from the [`develop` branch targetting the `main` branch](https://github.com/tipi-build/goldilock/compare/main...develop)
+- [ ] The PR ci.yaml will Create [a draft release](https://github.com/tipi-build/goldilock/releases)
+  - [ ] Check that all CI platform builds and tests properly
+  - [ ] Make the draft release public by tagging it
+  - [ ] Create integration PR within [hfc](https://github.com/tipi-build/hfc)
+  - [ ] Follow and finalize [a full HFC Release](https://github.com/tipi-build/hfc/blob/main/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md)
+- [ ] Once HFC with the new goldilock is tested
+  - [ ] goldilock pre-release can be made official
+  - [ ] Fast-forward release into main `git checkout main && git pull origin main --ff-only && git pull origin develop --ff-only`

--- a/.github/ISSUE_TEMPLATE/RELEASING.md
+++ b/.github/ISSUE_TEMPLATE/RELEASING.md
@@ -13,6 +13,7 @@ The goldilock development and release process follow the typical [git-flow](http
 To perform a new release, the following is required :
 
 - [ ] Merge fixes and features for the release in `develop`
+- [ ] Create a commit in `develop` that increments based on semver [`version_in_development`](https://github.com/tipi-build/goldilock/blob/main/.github/workflows/ci.yaml#L9)
 - [ ] Create a pull-request from the [`develop` branch targetting the `main` branch](https://github.com/tipi-build/goldilock/compare/main...develop)
 - [ ] The PR ci.yaml will Create [a draft release](https://github.com/tipi-build/goldilock/releases)
   - [ ] Check that all CI platform builds and tests properly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - develop
   pull_request:
 env:
-  version_in_development: v1.2.0
+  version_in_development: v1.2.1
 
 jobs:
   draft-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,9 @@ jobs:
         with:
           owner: tipi-build 
           repo: goldilock
-          commitish: ${{ github.sha }}
+          commitish: ${{ github.event.pull_request.head.sha }}
           tag_name: ${{ env.version_in_development }}
-          release_name: ${{ env.version_in_development }} ${{ github.sha }}
+          release_name: ${{ env.version_in_development }} ${{ github.event.pull_request.head.sha }}
           draft: true
           prerelease: true 
 
@@ -37,6 +37,8 @@ jobs:
     needs: draft-release
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: install and build 
         run: |
           cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
@@ -66,6 +68,8 @@ jobs:
     needs: draft-release
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: install and build 
         run: |
           cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
@@ -103,6 +107,8 @@ jobs:
     needs: draft-release
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: setup
         run: |
           sudo apt update

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,5 @@
 name: build
 on:
-  push:
-    branches:
-      - main
-      - develop
   pull_request:
 env:
   version_in_development: v1.2.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install and build 
         run: |
-          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
           cd build/macos/ && cpack -G ZIP
       - name: Upload goldilock package
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install and build 
         run: |
-          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
           cd build/macos/ 
           cpack -G ZIP
@@ -123,7 +123,7 @@ jobs:
           
       - name: install and build 
         run: |
-          tipi run cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17-static.cmake -DCMAKE_BUILD_TYPE=Release
+          tipi run cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17-static.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           tipi run cmake --build build/linux
           cd build/linux/
           tipi run cpack -G ZIP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ project(goldilock
   LANGUAGES CXX
 )
 
-enable_testing()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -47,4 +45,10 @@ target_include_directories(libgoldilock-utils INTERFACE
 )
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+# BUILD_TESTING is CTest module's default, but we prefer it OFF by default
+# Instead of include(CTest) we check on the option ourselves.
+if (BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -58,22 +58,23 @@ Usage:
 Building
 --------
 
-Build using `tipi` (substitute the toolchain your platform of choice e.g. `windows-cxx17` or `vs-16-2019-win64-cxx17` etc...)
+By using the provided `cmake` build system:
 
 ```shell
-tipi . -t linux-cxx17
-```
-
-... or by using the provided `cmake` build system:
-
-```shell
-mkdir -p build/linux
-cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17.cmake
+cmake -S . -B build/linux -GNinja -DBUILD_TESTING=ON
 cmake --build build/linux
 ```
 
+Developing the project
+--------
+If you plan to develop the project and contribute to it, you will need to enable `-DBUILD_TESTING=ON`.
+
+```shell
+cmake -S . -B build/linux -GNinja -DBUILD_TESTING=ON
+cmake --build build/linux
+```
 
 License
 -------
 
-`goldilock` is available under a proprietary license or subject to GPLv2 licence as per your choice. Please contact [tipi technologies Ltd.](https://tipi.build/) for commercial options.
+`goldilock` is available under a proprietary license or subject to GPLv2 licence as per your choice. Please contact [tipi technologies Ltd.](https://tipi.build/) for more details.

--- a/include/goldilock/version.hpp.in
+++ b/include/goldilock/version.hpp.in
@@ -2,6 +2,6 @@
 #include <string>
 
 namespace tipi::goldilock {
-    const std::string GOLDILOCK_VERSION = "v1.2.0";
+    const std::string GOLDILOCK_VERSION = "v1.2.1";
     const std::string GOLDILOCK_GIT_REVISION = "@GOLDILOCK_GIT_REVISION@";
 }

--- a/test/test_helpers.hpp
+++ b/test/test_helpers.hpp
@@ -12,6 +12,8 @@
 #include <iostream>
 #include <string>
 #include <optional>
+#include <thread>
+
 
 
 namespace goldilock::test { 


### PR DESCRIPTION
This is releasing fixes to build goldilock from sources without building the actual tests, which simplifies provisioning on hardware/OS platform that are not officially supported.

Fix tipi-build/specs-cmake-re#62