### PR TITLE
CI build static linux arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     name: Draft Release if develop branch
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.draft_release.outputs.upload_url }}  
-      release_id: ${{ steps.draft_release.outputs.id }}  
+      upload_url: ${{ steps.draft_release.outputs.upload_url }}
+      release_id: ${{ steps.draft_release.outputs.id }}
     steps:
       - name: Create Release
         id: draft_release
@@ -21,32 +21,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          owner: tipi-build 
+          owner: tipi-build
           repo: goldilock
           commitish: ${{ github.event.pull_request.head.sha }}
           tag_name: ${{ env.version_in_development }}
           release_name: ${{ env.version_in_development }} ${{ github.event.pull_request.head.sha }}
           draft: true
-          prerelease: true 
+          prerelease: true
 
   build-macos:
     name: build-macos
     runs-on: macos-latest
-    permissions:  
+    permissions:
       contents: write
     needs: draft-release
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: install and build 
+      - name: install and build
         run: |
           cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
           cd build/macos/ && cpack -G ZIP
       - name: Upload goldilock package
         if: ${{needs.draft-release.outputs.upload_url}}
-        id: upload-tipi-goldilock-package 
+        id: upload-tipi-goldilock-package
         uses: actions/upload-release-asset@v1
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           asset_content_type: application/zip
       - name: Run tests
         run: |
-          cd build/macos/ 
+          cd build/macos/
           ctest --verbose -E test_docker
 
   build-macos-intel:
@@ -70,15 +70,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: install and build 
+      - name: install and build
         run: |
           cmake -S . -B build/macos -DCMAKE_TOOLCHAIN_FILE=environments/macos-clang-cxx17.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build build/macos
-          cd build/macos/ 
+          cd build/macos/
           cpack -G ZIP
       - name: Upload goldilock package
         if: ${{needs.draft-release.outputs.upload_url}}
-        id: upload-tipi-goldilock-package 
+        id: upload-tipi-goldilock-package
         uses: actions/upload-release-asset@v1
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,61 +90,65 @@ jobs:
       - name: Run tests
         run: |
 
-          cd build/macos/ 
+          cd build/macos/
           ctest --verbose -E test_docker
 
   build-linux:
-    name: build-linux
-    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
+    name: build-linux-${{ matrix.os }}
     permissions:
       contents: write
-    container: 
-      image: tipibuild/tipi-ubuntu:latest
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-      # --init makes sure the container has an init process running as as the PID 1 in the container. Specifying an init process ensures the usual responsibilities of an init system, such as reaping zombie processes, are performed inside the created container.
-      options: --init
     needs: draft-release
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: setup
         run: |
+          # we need ninja
           sudo apt update
-          sudo apt-get install -y docker.io           
-
-          # the buildx plugin is available under either one of these names
-          set +e
-          sudo apt-get install -y docker-buildx 
-          sudo apt-get install -y docker-buildx-plugin
-          set -e
+          sudo apt-get install -y ninja-build
 
           sudo docker --version
           sudo docker buildx version
-          
-      - name: install and build 
+
+      - name: install and build
         run: |
-          tipi run cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-cxx17-static.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
-          tipi run cmake --build build/linux
+          cmake -S . -B build/linux -GNinja -DCMAKE_TOOLCHAIN_FILE=environments/linux-clang-14-cxx17-static.cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build build/linux
           cd build/linux/
-          tipi run cpack -G ZIP
+
+          # this tests that the binary is statically linked and fails if it isn't
+          file src/goldilock | grep -q 'statically linked'
+
+          cpack -G ZIP
+
+      - name: determine build architecture for packaging
+        run: |
+          echo "BUILD_ARCHITECTURE=$(uname -i)" >> $GITHUB_ENV
 
       - name: Upload goldilock package
         if: ${{needs.draft-release.outputs.upload_url}}
-        id: upload-tipi-goldilock-package 
+        id: upload-tipi-goldilock-package
         uses: actions/upload-release-asset@v1
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{needs.draft-release.outputs.upload_url}}
           asset_path: ./build/linux/goldilock.zip
-          asset_name: goldilock-linux.zip
+          asset_name: goldilock-linux-${{ env.BUILD_ARCHITECTURE }}.zip
           asset_content_type: application/zip
+
       - name: Run tests
         run: |
-          cd build/linux/ 
-          tipi run ctest --verbose -E test_docker
+          cd build/linux/
+          ctest --verbose -E test_docker
+
       - name: Run docker tests
         run: |
 
@@ -153,12 +157,12 @@ jobs:
           export SHARE_VOLUME_FOLDER=_dind_shared_volume
           export GOLDILOCK_TEST_DIND_SHARED_VOLUME_CONTAINER=${{ github.workspace }}/$SHARE_VOLUME_FOLDER
           export GOLDILOCK_TEST_DIND_SHARED_VOLUME_HOST=${{ github.workspace }}/$SHARE_VOLUME_FOLDER
-          export GOLDILOCK_TEST_DIND_SHARED_VOLUME_TEST=$(pwd)/$SHARE_VOLUME_FOLDER          
-          
-          # create the folder from the test environmnent's perspective: 
+          export GOLDILOCK_TEST_DIND_SHARED_VOLUME_TEST=$(pwd)/$SHARE_VOLUME_FOLDER
+
+          # create the folder from the test environmnent's perspective:
           mkdir -p $GOLDILOCK_TEST_DIND_SHARED_VOLUME_TEST
           echo "hello" > $GOLDILOCK_TEST_DIND_SHARED_VOLUME_TEST/test_from_ci_yaml
 
           cd build/linux/
           # ... we need priviledge to write to the docker socket
-          sudo --preserve-env tipi run ctest --verbose -R test_docker
+          sudo --preserve-env ctest --verbose -R test_docker

--- a/environments/helpers/clang-libcxx.cmake
+++ b/environments/helpers/clang-libcxx.cmake
@@ -1,0 +1,202 @@
+
+# run the passed llvm-config to retrieve information about that installation
+macro(llvm_config_get llvm_config_binary var flag)
+  set(result_code)
+  execute_process(
+    COMMAND ${llvm_config_binary} --link-static --${flag}
+    RESULT_VARIABLE result_code
+    OUTPUT_VARIABLE LLVM_${var}
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(result_code)
+    message(FATAL_ERROR "Failed to execute llvm-config ('${llvm_config_binary}', result code: '${result_code})'")
+  else()
+    if(${ARGV3})
+      file(TO_CMAKE_PATH "${LLVM_${var}}" LLVM_${var})
+    endif()
+  endif()
+endmacro()
+
+function(llvm_get_version llvm_config_executable OUT_result)
+  llvm_config_get(${llvm_config_executable} VERSION_STRING version)
+
+  # The LLVM version string _may_ contain a git/svn suffix, so match only the x.y.z part
+  string(REGEX MATCH "^[0-9]+[.][0-9]+[.][0-9]+" LLVM_VERSION_BASE_STRING "${LLVM_VERSION_STRING}")
+  set(${OUT_result} ${LLVM_VERSION_BASE_STRING} PARENT_SCOPE)
+endfunction()
+
+function(clang_major_version_check_equal llvm_config_executable expected_version)
+  llvm_get_version(${llvm_config_executable} version)
+  string(REGEX REPLACE "([0-9]+).*" "\\1" major_version "${version}" )
+
+  if (NOT "${major_version}" VERSION_EQUAL "${expected_version}")
+    message(FATAL_ERROR "Unsupported LLVM version ${LLVM_VERSION_STRING} found (${llvm_config_executable}). Major version equal to ${expected_version} is required.")
+  endif()
+endfunction()
+
+function(clang_check_minimum_version llvm_config_executable expected_version)
+  llvm_get_version(${llvm_config_executable} version)
+
+  if (NOT "${version}" VERSION_GREATER_EQUAL "${expected_version}")
+    message(FATAL_ERROR "Unsupported LLVM version ${LLVM_VERSION_STRING} found (${llvm_config_executable}). At least version ${expected_version} is required.")
+  endif()
+endfunction()
+
+
+function(llvm_get_include_dir llvm_config_executable OUT_result)
+  llvm_config_get(${llvm_config_executable} INCLUDE_DIRS includedir true)
+  set(${OUT_result} ${LLVM_INCLUDE_DIRS} PARENT_SCOPE)
+endfunction()
+
+function(llvm_get_root_dir llvm_config_executable OUT_result)
+  llvm_config_get(${llvm_config_executable} ROOT_DIR prefix true)
+  set(${OUT_result} ${LLVM_ROOT_DIR} PARENT_SCOPE)
+endfunction()
+
+function(llvm_get_library_dir llvm_config_executable OUT_result)
+  llvm_config_get(${llvm_config_executable} LIBRARY_DIRS libdir true)
+  set(${OUT_result} ${LLVM_LIBRARY_DIRS} PARENT_SCOPE)
+endfunction()
+
+function(llvm_get_cmake_dir llvm_config_executable OUT_result)
+  llvm_config_get(${llvm_config_executable} CMAKEDIR cmakedir true)
+  set(${OUT_result} ${LLVM_CMAKEDIR} PARENT_SCOPE)
+endfunction()
+
+# find the paths to the static libc++ and libc++abi of the discovered llvm/clang installation
+# Usages:
+#
+# find_libcxx_static(<llvm_config_binary> RESULT_LIBCXX_PATH <variable name> RESULT_LIBCXXABI_PATH <variable_name> [FAIL_NOTFOUND])
+function(find_libcxx_static llvm_config_binary)
+
+  set(options_params FAIL_NOTFOUND)
+  set(one_value_args RESULT_LIBCXX_PATH RESULT_LIBCXXABI_PATH)
+  set(multi_value_params )
+
+  cmake_parse_arguments(FN_ARG "${options_params}" "${one_value_args}" "${multi_value_params}" ${ARGN})
+
+  # interogate llvm-config
+  llvm_get_library_dir(${llvm_config_binary} LLVM_LIBRARY_DIRS)
+
+  set(libcxx_path "${LLVM_LIBRARY_DIRS}/libc++.a")
+  set(libcxxabi_path "${LLVM_LIBRARY_DIRS}/libc++abi.a")
+
+  if(EXISTS "${libcxx_path}" AND EXISTS "${libcxxabi_path}")
+    set(${FN_ARG_RESULT_LIBCXX_PATH} "${libcxx_path}" PARENT_SCOPE)
+    set(${FN_ARG_RESULT_LIBCXXABI_PATH} "${libcxxabi_path}" PARENT_SCOPE)
+  elseif(FN_ARG_FAIL_NOTFOUND)
+    message(FATAL_ERROR "Did not find a matching libc++ to the llvm/clang installation described by ${llvm_config_binary}")
+  else()
+    set(${FN_ARG_RESULT_LIBCXX_PATH} NOTFOUND PARENT_SCOPE)
+    set(${FN_ARG_RESULT_LIBCXXABI_PATH} NOTFOUND PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+# Find a llvm/clang installtion on the system:
+# Usage:
+#
+# find_clang(
+#   [VERSIONS <list>]
+#   [HINT_PATHS <list>]
+#   [RESULT_CLANG_C_COMPILER <variable name>]
+#   [RESULT_CLANG_CXX_COMPILER <variable name>]
+#   [RESULT_LLVM_CONFIG_EXECUTABLE <variable name>]
+#   [FAIL_NOTFOUND]
+# )
+function(find_clang)
+  set(options_params
+    FAIL_NOTFOUND
+  )
+
+  set(one_value_args
+    VERSIONS
+    HINT_PATHS
+    RESULT_CLANG_C_COMPILER
+    RESULT_CLANG_CXX_COMPILER
+    RESULT_LLVM_CONFIG_EXECUTABLE
+  )
+
+  set(multi_value_params )
+
+  cmake_parse_arguments(FN_ARG "${options_params}" "${one_value_args}" "${multi_value_params}" ${ARGN})
+
+  set(clang_names "")
+  set(clangpp_names "")
+  set(llvm_config_names "")
+
+  if(NOT FN_ARG_VERSIONS)
+    list(APPEND clang_names "clang")
+    list(APPEND clangpp_names "clang++")
+    list(APPEND llvm_config_names "llvm-config")
+  else()
+    foreach(version IN LISTS FN_ARG_VERSIONS)
+      if(version STREQUAL "")
+        list(APPEND clang_names "clang")
+        list(APPEND clangpp_names "clang++")
+        list(APPEND llvm_config_names "llvm-config")
+      else()
+        list(APPEND clang_names "clang-${version}")
+        list(APPEND clangpp_names "clang++-${version}")
+        list(APPEND llvm_config_names "llvm-config-${version}")
+      endif()
+    endforeach()
+  endif()
+
+  list(REMOVE_DUPLICATES clang_names)
+  list(REMOVE_DUPLICATES clangpp_names)
+  list(REMOVE_DUPLICATES llvm_config_names)
+
+  find_program(LLVM_CONFIG_EXECUTABLE
+    NAMES ${llvm_config_names}
+    PATHS ${FN_ARG_HINT_PATHS}
+    ENV LLVM_PATH
+    NO_CACHE
+  )
+
+  if(LLVM_CONFIG_EXECUTABLE)
+    message(STATUS "Found llvm-config: ${LLVM_CONFIG_EXECUTABLE}")
+  elseif(FN_ARG_FAIL_NOTFOUND)
+    message(FATAL_ERROR "Can't find program: llvm-config (searched for ${llvm_config_names})")
+  endif()
+
+  find_program(CLANG_C_COMPILER_EXECUTABLE
+    NAMES ${clang_names}
+    PATHS ${FN_ARG_HINT_PATHS}
+    ENV LLVM_PATH
+    NO_CACHE
+  )
+
+  if(CLANG_C_COMPILER_EXECUTABLE)
+    message(STATUS "Found clang: ${CLANG_C_COMPILER_EXECUTABLE}")
+  elseif(FN_ARG_FAIL_NOTFOUND)
+    message(FATAL_ERROR "Can't fing program: clang (searched for ${clang_names})")
+  endif()
+
+  find_program(CLANG_CXX_COMPILER_EXECUTABLE
+    NAMES ${clangpp_names}
+    PATHS ${FN_ARG_HINT_PATHS}
+    ENV LLVM_PATH
+    NO_CACHE
+  )
+
+  if(CLANG_CXX_COMPILER_EXECUTABLE)
+    message(STATUS "Found clang++: ${CLANG_CXX_COMPILER_EXECUTABLE}")
+  elseif(FN_ARG_FAIL_NOTFOUND)
+    message(FATAL_ERROR "Can't fing program: clang++ (searched for ${clangpp_names})")
+  endif()
+
+  if(FN_ARG_RESULT_CLANG_C_COMPILER)
+    set(${FN_ARG_RESULT_CLANG_C_COMPILER} ${CLANG_C_COMPILER_EXECUTABLE} PARENT_SCOPE)
+  endif()
+
+  if(FN_ARG_RESULT_CLANG_CXX_COMPILER)
+    set(${FN_ARG_RESULT_CLANG_CXX_COMPILER} ${CLANG_CXX_COMPILER_EXECUTABLE} PARENT_SCOPE)
+  endif()
+
+  if(FN_ARG_RESULT_LLVM_CONFIG_EXECUTABLE)
+    set(${FN_ARG_RESULT_LLVM_CONFIG_EXECUTABLE} ${LLVM_CONFIG_EXECUTABLE} PARENT_SCOPE)
+  endif()
+
+endfunction()

--- a/environments/linux-clang-14-cxx17-static.cmake
+++ b/environments/linux-clang-14-cxx17-static.cmake
@@ -1,0 +1,29 @@
+include_guard()
+
+include(${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/helpers/clang-libcxx.cmake)
+
+set(expected_clang_version 14)
+
+find_clang(
+  VERSIONS ${expected_clang_version}
+  RESULT_CLANG_C_COMPILER clang_C_COMPILER
+  RESULT_CLANG_CXX_COMPILER clang_CXX_COMPILER
+  RESULT_LLVM_CONFIG_EXECUTABLE llvm_config_executable
+  FAIL_NOTFOUND
+)
+
+clang_major_version_check_equal(${llvm_config_executable} ${expected_clang_version})
+
+set(CMAKE_C_COMPILER "${clang_C_COMPILER}" CACHE STRING "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER "${clang_CXX_COMPILER}" CACHE STRING "C++ compiler" FORCE)
+
+# true full static build by specifying the paths to libc++ and libc++abi as we got them through discovery
+# the combination of -static, -stdlib=libc++, -static-libstdc++ and the full path to the libc++(abi) archives
+# yield the desired result
+find_libcxx_static(${llvm_config_executable} RESULT_LIBCXX_PATH libcxx_path RESULT_LIBCXXABI_PATH libcxxabi_path FAIL_NOTFOUND)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -static -stdlib=libc++ -static-libstdc++ ${libcxx_path} ${libcxxabi_path}")
+set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+message(STATUS "Using libc++ at ${libcxx_path} for static build")
+message(STATUS "Using libc++abi at ${libcxxabi_path} for static build")

--- a/environments/linux-clang-16-cxx17-static.cmake
+++ b/environments/linux-clang-16-cxx17-static.cmake
@@ -1,0 +1,29 @@
+include_guard()
+
+include(${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/helpers/clang-libcxx.cmake)
+
+set(expected_clang_version 16)
+
+find_clang(
+  VERSIONS ${expected_clang_version}
+  RESULT_CLANG_C_COMPILER clang_C_COMPILER
+  RESULT_CLANG_CXX_COMPILER clang_CXX_COMPILER
+  RESULT_LLVM_CONFIG_EXECUTABLE llvm_config_executable
+  FAIL_NOTFOUND
+)
+
+clang_major_version_check_equal(${llvm_config_executable} ${expected_clang_version})
+
+set(CMAKE_C_COMPILER "${clang_C_COMPILER}" CACHE STRING "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER "${clang_CXX_COMPILER}" CACHE STRING "C++ compiler" FORCE)
+
+# true full static build by specifying the paths to libc++ and libc++abi as we got them through discovery
+# the combination of -static, -stdlib=libc++, -static-libstdc++ and the full path to the libc++(abi) archives
+# yield the desired result
+find_libcxx_static(${llvm_config_executable} RESULT_LIBCXX_PATH libcxx_path RESULT_LIBCXXABI_PATH libcxxabi_path FAIL_NOTFOUND)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -static -stdlib=libc++ -static-libstdc++ ${libcxx_path} ${libcxxabi_path}")
+set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+message(STATUS "Using libc++ at ${libcxx_path} for static build")
+message(STATUS "Using libc++abi at ${libcxxabi_path} for static build")

--- a/environments/linux-tipi-clang-cxx17-static.cmake
+++ b/environments/linux-tipi-clang-cxx17-static.cmake
@@ -1,0 +1,30 @@
+include_guard()
+
+include(${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/helpers/clang-libcxx.cmake)
+
+set(expected_clang_version 13)
+
+find_clang(
+  VERSIONS "" # tipi's clang has no version suffix (just "clang")
+  HINT_PATHS "/usr/local/share/.tipi/clang/"
+  RESULT_CLANG_C_COMPILER clang_C_COMPILER
+  RESULT_CLANG_CXX_COMPILER clang_CXX_COMPILER
+  RESULT_LLVM_CONFIG_EXECUTABLE llvm_config_executable
+  FAIL_NOTFOUND
+)
+
+clang_major_version_check_equal(${llvm_config_executable} ${expected_clang_version})
+
+set(CMAKE_C_COMPILER "${clang_C_COMPILER}" CACHE STRING "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER "${clang_CXX_COMPILER}" CACHE STRING "C++ compiler" FORCE)
+
+# true full static build by specifying the paths to libc++ and libc++abi as we got them through discovery
+# the combination of -static, -stdlib=libc++, -static-libstdc++ and the full path to the libc++(abi) archives
+# yield the desired result
+find_libcxx_static(${llvm_config_executable} RESULT_LIBCXX_PATH libcxx_path RESULT_LIBCXXABI_PATH libcxxabi_path FAIL_NOTFOUND)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -static -stdlib=libc++ -static-libstdc++ ${libcxx_path} ${libcxxabi_path}")
+set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+message(STATUS "Using libc++ at ${libcxx_path} for static build")
+message(STATUS "Using libc++abi at ${libcxxabi_path} for static build")


### PR DESCRIPTION
Added a static ubuntu-arm64 build on GHA runners

- Changed how the static clang toolchain(s) do compiler and stdlib discovery to unify both linux builds 
- have them work on the github actions runner images for both Ubuntu 22.04 ARM64 and Ubuntu 22.04 x86_64